### PR TITLE
Update noipupdater.sh

### DIFF
--- a/noipupdater.sh
+++ b/noipupdater.sh
@@ -139,7 +139,7 @@ else
 fi
 
 LOGDATE="[$(date +'%Y-%m-%d %H:%M:%S')]"
-SRESULT=$([[ $RESULT =~ (^[a-z\!0-9]+) ]] && echo "${BASH_REMATCH[1]}")
+SRESULT=$(echo $RESULT | awk '{ print $1 }')
 case $SRESULT in
     "good")
         LOGLINE="$LOGDATE (good) DNS hostname(s) successfully updated to $NEWIP."


### PR DESCRIPTION
Regular expression misbehaves on older GNU bash, reverting to a simple awk callout. Should still work in later versions, verified on:
GNU bash, version 3.00.15(1)-release (i686-redhat-linux-gnu)
GNU bash, version 3.2.17(1)-release (i386-apple-darwin9.0)
