### PR TITLE
Update readme.md, add dependency to vim

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@ A bash script to update the IP address of a no-ip.com hostname.
 __Prerequisites__
 
 1.  curl
+2.  vim
 
 __Usage__
 


### PR DESCRIPTION
xxd is not a required package for debian:
./noipupdater.sh: line 35: xxd: command not found
./noipupdater.sh: line 36: xxd: command not found

xxd comes with vim so this should be added as a dependency 