### PR TITLE
Tell no-ip whose software this is.

### DIFF
--- a/noipupdater.sh
+++ b/noipupdater.sh
@@ -17,6 +17,8 @@
 
 # Defines
 
+MAINTAINER="https://github.com/mdmower"
+
 CONFIGFILE="$( cd "$( dirname "$0" )" && pwd )/config"
 
 if [ -e "$CONFIGFILE" ]; then
@@ -31,7 +33,7 @@ if [ -z "$USERNAME" ] || [ -z "$PASSWORD" ]; then
    exit 1
 fi
 
-USERAGENT="Bash No-IP Updater/1.0 $USERNAME"
+USERAGENT="Bash No-IP Updater/1.0 $MAINTAINER"
 
 USERNAME=$(echo -ne "$USERNAME" | od -A n -t x1 | tr -d '\n' | sed 's/ /%/g')
 PASSWORD=$(echo -ne "$PASSWORD" | od -A n -t x1 | tr -d '\n' | sed 's/ /%/g')


### PR DESCRIPTION
Their docs explicitly request this https://www.noip.com/integrate/request. Passing the username is not what they want; they want someone who can bugfix clients gone astray.