### PR TITLE
Better urlencode

### DIFF
--- a/noipupdater.sh
+++ b/noipupdater.sh
@@ -59,8 +59,29 @@ function cmd_exists() {
     command -v "$1" > /dev/null 2>&1
 }
 
+# https://unix.stackexchange.com/questions/60653/urlencode-function/60698#60698 (thanks @gilles! this code is great!)
 function urlencode() {
-    od -A n -t x1 | tr -d '\n' | sed 's/ /%/g'
+  read string;
+  format=; set --
+  while
+    literal=${string%%[!-._~0-9A-Za-z]*}
+    case "$literal" in
+      ?*)
+        format=$format%s
+        set -- "$@" "$literal"
+        string=${string#$literal};;
+    esac
+    case "$string" in
+      "") false;;
+    esac
+  do
+    tail=${string#?}
+    head=${string%$tail}
+    format=$format%%%02x
+    set -- "$@" "'$head"
+    string=$tail
+  done
+  printf "$format\\n" "$@"
 }
 
 function http_get() {

--- a/noipupdater.sh
+++ b/noipupdater.sh
@@ -161,6 +161,11 @@ if [ "$ROTATE_LOGS" = true ]; then
     fi
 fi
 
+OIFS=$IFS
+IFS=','
+SPLIT_HOST=( $(echo "$HOST") )
+IFS=$OIFS
+
 USERNAME=$(echo -ne "$USERNAME" | urlencode)
 PASSWORD=$(echo -ne "$PASSWORD" | urlencode)
 HOST=$(echo -ne "$HOST" | urlencode)
@@ -169,8 +174,6 @@ RESPONSE=$(http_get "https://$USERNAME:$PASSWORD@dynupdate.no-ip.com/nic/update?
 OIFS=$IFS
 IFS=$'\n'
 SPLIT_RESPONSE=( $(echo "$RESPONSE" | grep -o '[0-9a-z!]\+\( [0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\)\?') )
-IFS=','
-SPLIT_HOST=( $(echo "$HOST") )
 IFS=$OIFS
 
 LOGDATE="[$(date +'%Y-%m-%d %H:%M:%S')]"


### PR DESCRIPTION
The existing urlencode encodes every character. This is legal, but the RFC suggests that the safelist of latin alphanumerics should not be encoded. It certainly makes reading logs harder. This replacement (thanks stackoverflow!!) handles the safelist properly, and manages to do it all in pure bash.

Depends #7.
Conflicts #14, because that one patched the same function.